### PR TITLE
feat(*): waves of enemies

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -23,38 +23,54 @@
 
         <section class="hud">
             <div class="boxed">
-                <p>Number of enemies:
-                    <strong>
-                        <span id="num-enemies"><!-- dynamic --></span>
-                    </strong>
-                </p>
-                <p>Player score:
+              <p>Number of enemies:
                   <strong>
-                      <span id="player-score"><!-- dynamic --></span>
+                      <span id="enemies-remaining"><!-- dynamic --></span>
                   </strong>
-                </p>
-                <p>Team score:
-                    <strong>
-                        <span id="team-score"><!-- dynamic --></span>
-                    </strong>
-                </p>
-              </div>
+              </p>
+              <p>Player score:
+                <strong>
+                    <span id="player-score"><!-- dynamic --></span>
+                </strong>
+              </p>
+              <p>Team score:
+                  <strong>
+                      <span id="team-score"><!-- dynamic --></span>
+                  </strong>
+              </p>
+            </div>
 
-              <div class="boxed">
-                <p>Lives:
+            <div class="boxed">
+              <p>Wave:
+                <strong>
+                    <span id="wave-num"><!-- dynamic --></span>
+                </strong>
+              </p>
+            </div>
+
+            <div class="boxed">
+              <p>Lives:
+                <strong>
+                    <span id="player-lives"><!-- dynamic --></span>
+                </strong>
+              </p>
+              <p>Ammo:
                   <strong>
-                      <span id="player-lives"><!-- dynamic --></span>
+                      <span id="player-ammo"><!-- dynamic --></span>
                   </strong>
-                </p>
-                <p>Ammo:
-                    <strong>
-                        <span id="player-ammo"><!-- dynamic --></span>
-                    </strong>
-                    (<span id="player-weapon"><!-- dynamic --></span>)
-                </p>
-              </div>
+                  (<span id="player-weapon"><!-- dynamic --></span>)
+              </p>
+            </div>
         </section>
 
+    </div>
+
+    <div class="overlay toast" id="wave-toast">
+      <div class="centered">
+          <h1 class="announce">WAVE
+            <span id="wave-num-toast"><!-- dynamic --></span>
+          </h1>
+      </div>
     </div>
   </div>
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -23,7 +23,7 @@
 
         <section class="hud">
             <div class="boxed">
-              <p>Number of enemies:
+              <p>Remaining enemies:
                   <strong>
                       <span id="enemies-remaining"><!-- dynamic --></span>
                   </strong>

--- a/dev/lib/game.js
+++ b/dev/lib/game.js
@@ -14,9 +14,10 @@ class Game {
       this.enemies = {};
       this.items = {};
 
-      // Moved from Enemy class, since this will vary by game
-      // Chance starts at once per 5 seconds
-      this.chanceForEnemiesToGenerate = 1 / (5 * FPS);
+      this.totalEnemies = 0;
+      this.waveNum = 0;
+      this.waveKills = 0;
+      this.nextWave();
 
       console.log(`[Game constructor] New game created: ${this.id}`);
       GAMES[this.id] = this;
@@ -43,6 +44,13 @@ class Game {
       }
       return packs;
     }
+    getState() {
+      return {
+        totalEnemies: this.totalEnemies,
+        waveKills: this.waveKills,
+        waveNum: this.waveNum,
+      }
+    }
     createInitialObstacles() {
       // Create some initial obstacles to prevent "empty" beginning screen
       for (let i = 0; i < INITIAL_OBSTACLES; i++) {
@@ -50,6 +58,34 @@ class Game {
           gameId: this.id,
           y: getRandomInt(0, MAP_HEIGHT),// overwrite default y, which is below viewport
         });
+      }
+    }
+    decrementRemainingEnemies() {
+      this.remainingEnemies--;
+    }
+    incrementWaveKills() {
+      this.waveKills++;
+      if (this.waveKills >= this.totalEnemies) {
+        this.nextWave();
+      }
+    }
+    nextWave() {
+      this.waveKills = 0;
+      this.waveNum++;
+      const wave = Game.waves[this.waveNum];
+      if (wave) {
+        this.totalEnemies = wave.numEnemies
+        this.remainingEnemies = this.totalEnemies;
+        this.chanceForEnemiesToGenerate = wave.chanceForEnemiesToGenerate;
+        this.chancesForWeapons = wave.chancesForWeapons;
+      } else {
+        this.totalEnemies = Math.floor(this.totalEnemies * 1.25);
+        this.remainingEnemies = this.totalEnemies;
+        this.chanceForEnemiesToGenerate *= 1.05;
+        this.chancesForWeapons = [
+          // Could do anything here
+          { name: 'shotgun', chance: 1.00 }
+        ];
       }
     }
     static findOrCreateGame() {
@@ -87,5 +123,87 @@ class Game {
     'obstacles': Obstacle,
     'items': Item,
   };
+  // Chance starts at once per 3 seconds
+  Game.defaultChanceForEnemiesToGenerate = 1 / (3 * FPS);
+  Game.waves = {
+    1: {
+      numEnemies: 10,
+      chancesForWeapons: [
+        // chances should sum to 1
+        { name: 'shotgun',  chance: 0.00 },
+        { name: 'chaingun', chance: 0.00 },
+        { name: 'rifle', chance: 0.00 },
+        { name: 'burstshot', chance: 0.20 }, // high chance -> demo mechanic to user
+        { name: 'flamethrower', chance: 0.00 },
+        { name: 'pistol', chance: 0.80 },
+      ],
+      chanceForEnemiesToGenerate: Game.defaultChanceForEnemiesToGenerate,
+    },
+    2: {
+      numEnemies: 15,
+      chancesForWeapons: [
+        // chances should sum to 1
+        { name: 'shotgun',  chance: 0.00 },
+        { name: 'chaingun', chance: 0.15 },
+        { name: 'rifle', chance: 0.00 },
+        { name: 'burstshot', chance: 0.05 },
+        { name: 'flamethrower', chance: 0.00 },
+        { name: 'pistol', chance: 0.80 },
+      ],
+      chanceForEnemiesToGenerate: Game.defaultChanceForEnemiesToGenerate * 1.05,
+    },
+    3: {
+      numEnemies: 20,
+      chancesForWeapons: [
+        // chances should sum to 1
+        { name: 'shotgun',  chance: 0.15 },
+        { name: 'chaingun', chance: 0.05 },
+        { name: 'rifle', chance: 0.00 },
+        { name: 'burstshot', chance: 0.05 },
+        { name: 'flamethrower', chance: 0.00 },
+        { name: 'pistol', chance: 0.75 },
+      ],
+      chanceForEnemiesToGenerate: Game.defaultChanceForEnemiesToGenerate * 1.10,
+    },
+    4: {
+      numEnemies: 25,
+      chancesForWeapons: [
+        // chances should sum to 1
+        { name: 'shotgun',  chance: 0.05 },
+        { name: 'chaingun', chance: 0.05 },
+        { name: 'rifle', chance: 0.15 },
+        { name: 'burstshot', chance: 0.05 },
+        { name: 'flamethrower', chance: 0.00 },
+        { name: 'pistol', chance: 0.70 },
+      ],
+      chanceForEnemiesToGenerate: Game.defaultChanceForEnemiesToGenerate * 1.20,
+    },
+    5: {
+      numEnemies: 35,
+      chancesForWeapons: [
+        // chances should sum to 1
+        { name: 'shotgun',  chance: 0.05 },
+        { name: 'chaingun', chance: 0.05 },
+        { name: 'rifle', chance: 0.05 },
+        { name: 'burstshot', chance: 0.05 },
+        { name: 'flamethrower', chance: 0.15 },
+        { name: 'pistol', chance: 0.65 },
+      ],
+      chanceForEnemiesToGenerate: Game.defaultChanceForEnemiesToGenerate * 1.30,
+    },
+    6: {
+      numEnemies: 50,
+      chancesForWeapons: [
+        // chances should sum to 1
+        { name: 'shotgun',  chance: 0.07 },
+        { name: 'chaingun', chance: 0.07 },
+        { name: 'rifle', chance: 0.07 },
+        { name: 'burstshot', chance: 0.07 },
+        { name: 'flamethrower', chance: 0.07 },
+        { name: 'pistol', chance: 0.65 },
+      ],
+      chanceForEnemiesToGenerate: Game.defaultChanceForEnemiesToGenerate * 1.50,
+    },
+  }
 
   /* Not using module.exports because require() is unavailable in the sandbox environment */

--- a/dev/server.js
+++ b/dev/server.js
@@ -25,6 +25,9 @@ setInterval(() => {
     io.to(game.room).emit('update', packs.updatePack);
     io.to(game.room).emit('remove', packs.removePack);
 
+    const gameState = game.getState();
+    io.to(game.room).emit('state', gameState);
+
     // Delete empty games (otherwise they will remain with logic continuing
     // for all non-player entities). TODO: this should only be checked in
     // onDisconnect events, and not every frame. However, currently player

--- a/dev/static/style.css
+++ b/dev/static/style.css
@@ -28,6 +28,47 @@ canvas {
   width: 100%;
 }
 
+.centered {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
+h1.announce {
+  font-size: 3em;
+}
+
+.toast {
+  visibility: hidden;
+}
+
+.toast.show {
+  visibility: visible;
+  -webkit-animation: fadein 1.5s, fadeout 1.5s 2.5s;
+  animation: fadein 1.5s, fadeout 1.5s 2.5s;
+}
+
+@-webkit-keyframes fadein {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fadein {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@-webkit-keyframes fadeout {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes fadeout {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
 .hud {
   display: flex;
   font-family: 'Courier New', Courier, monospace;


### PR DESCRIPTION
This commit implements "waves" of enemies as a mechanic

Logic changes:
* Waves are defined in the Game class:
    * Initial 6 waves are defined explicitly with number of enemies,
chances for weapons, and enemy spawn rates
    * After that wave properties are programmatically increased
* New “STATE” data about game wave is transmitted between client and server
* game wave instance tracks enemies remaining & enemies killed

Refactors:
* Moves chances for weapons from Enemy class to Game class
* Enemy generation rate is moved to game instance

UI changes:
* Show toasts on new waves
    * first wave toast is delayed
* Current wave number shown in HUD
* HUD's "Enemies" was changed to represent remaining enemies in the wave
(from representing enemies on screen)

Minor updates:
* updates max ammo displayed from 1000 to 9999
* Global enemy number cap is removed