### PR TITLE
feat: HUD styles

### DIFF
--- a/dev/client.js
+++ b/dev/client.js
@@ -106,6 +106,10 @@
           selfId = data.selfId;
         }
         for (let i = 0; i < data.players.length; i++) {
+          const player = data.players[i];
+          if (player.id === selfId) {
+            document.querySelector('.hud').style.color = player.color;
+          }
           new PlayerSprite(data.players[i]);
         }
         for (let i = 0; i < data.enemies.length; i++) {
@@ -219,11 +223,10 @@
         for (let playerId in PlayerSprite.sprites) {
           const player = PlayerSprite.sprites[playerId]
           if (player.id === selfId) {
-            if (player.weaponAmmo > 9999) { player.weaponAmmo = '∞' }
             playerScore.textContent  = player.score;
             playerLives.textContent  = player.lives;
-            playerAmmo.textContent   = player.weaponAmmo;
             playerWeapon.textContent = player.weaponName;
+            playerAmmo.textContent   = Math.min(player.weaponAmmo, 99999);
           }
           teamScore += player.score;
         }

--- a/dev/index.html
+++ b/dev/index.html
@@ -42,7 +42,7 @@
     <div class="overlay">
 
         <section class="hud">
-            <div class="boxed side-pad">
+            <div class="side-pad">
               <p>Remaining enemies:
                   <strong>
                       <span id="enemies-remaining"><!-- dynamic --></span>
@@ -60,7 +60,7 @@
               </p>
             </div>
 
-            <div class="boxed side-pad">
+            <div class="side-pad">
               <p>Wave:
                 <strong>
                     <span id="wave-num"><!-- dynamic --></span>
@@ -68,17 +68,21 @@
               </p>
             </div>
 
-            <div class="boxed side-pad">
+            <div class="side-pad">
               <p>Lives:
                 <strong>
                     <span id="player-lives"><!-- dynamic --></span>
                 </strong>
               </p>
+              <p>Weapon:
+                  <strong>
+                      <span id="player-weapon"><!-- dynamic --></span>
+                  </strong>
+                </p>
               <p>Ammo:
                   <strong>
                       <span id="player-ammo"><!-- dynamic --></span>
                   </strong>
-                  (<span id="player-weapon"><!-- dynamic --></span>)
               </p>
             </div>
         </section>

--- a/dev/lib/entities/player.js
+++ b/dev/lib/entities/player.js
@@ -296,7 +296,6 @@ class Player extends Entity {
     // seems like it would happen automatically
   }
 }
-//                red,       blue,      green,     orange
-Player.colors = ['#FF5733', '#16489E', '#33FF57', '#FFBD33'];
+Player.colors = ['#FF5733', '#4086fd', '#56f572', '#FFBD33'];
 
 /* Not using module.exports because require() is unavailable in the sandbox environment */

--- a/dev/static/style.css
+++ b/dev/static/style.css
@@ -105,6 +105,13 @@ a:hover, a:focus {
   justify-content: space-between;
   padding: 10px 25px;
   width: 100%;
+  /* provides an outline on text, so its still visible
+  when passing over lighter colors like obstacles */
+  text-shadow:
+    -1px -1px 0 #000,
+     1px -1px 0 #000,
+    -1px  1px 0 #000,
+     1px  1px 0 #000;
 }
 
 .boxed {


### PR DESCRIPTION
This commit cleans up the HUD content
* removes infinity sign for ammo - it was too small and off-center
* sets the font color to the color of the current player (which also helps
me remember what player I am!)
* adds a black outline to the HUD text so it's nice and readable
when passing over lighter colored obstacles
* removes boxes around text content
* brightens the blue player color and softens the green player color