### PR TITLE
feat(*): game over screen, player.dead prop

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -8,8 +8,8 @@
 <body>
 
 <main>
-  <div id="startScreen" class="startScreen">
-    <div class="startScreenMenu">
+  <div id="startScreen" class="screen">
+    <div class="menu">
       <h1 class="title">FALL BACK</h1>
       <section class="menu-item boxed">
         <h4>Mission</h4>
@@ -30,12 +30,34 @@
             </div>
         </div>
       </section>
-      <button id="btnStartGame" class='btn'>Start</button>
+      <button id="btnStartGame" class="btn">Start</button>
     </div>
     <a href="https://github.com/nasearle/fall-back" class="footer-url" target="_blank">Repo</a>
   </div>
 
-  <div id="gameUi" class="gameUi" hidden>
+  <div id="gameOverScreen" class="screen hidden">
+    <div id="gameStats" class="menu">
+      <h1>GAME OVER</h1>
+      <p>Team score:
+        <strong>
+          <span id="stats-team-score"><!-- dynamic --></span>
+        </strong>
+      </p>
+      <p>Player score:
+        <strong>
+          <span id="stats-player-score"><!-- dynamic --></span>
+        </strong>
+      </p>
+      <p>Wave reached:
+        <strong>
+          <span id="stats-wave-reached"><!-- dynamic --></span>
+        </strong>
+      </p>
+      <button id="btnPlayAgain" class="btn">Play Again</button>
+    </div>
+  </div>
+
+  <div id="gameUi" class="gameUi hidden">
     <canvas id="ctx" width="500" height="500"></canvas>
 
     <!-- Everything that isn't canvas should overlay on top of it -->

--- a/dev/lib/entities/bullet.js
+++ b/dev/lib/entities/bullet.js
@@ -17,7 +17,7 @@ class Bullet extends Entity {
     this.damage = parent.weapon.damage;
     this.toRemove = false;
     this.color = this.parent.color;
-    this.ttl = 100; // time to leave
+    this.ttl = 100; // time to live
 
     GAMES[this.gameId].bullets[this.id] = this;
     GAMES[this.gameId].initPack.bullets.push(this.getInitPack());
@@ -61,7 +61,7 @@ class Bullet extends Entity {
     if (this.parent.type != 'player') { // No friendly fire
       for (let id in game.players) {
         let player = game.players[id];
-        if (Entity.overlaps(this, player)) {
+        if (!player.dead && Entity.overlaps(this, player)) {
           player.hp -= this.damage;
           this.toRemove = true;
         }

--- a/dev/lib/entities/enemy.js
+++ b/dev/lib/entities/enemy.js
@@ -4,10 +4,7 @@ class Enemy extends Entity {
     this.type = 'enemy';
     this.id = generateId();
     this.gameId = gameId;
-    // TODO: this line can cause a a crash if enemy spawns when players are dead
-    // since it doesn't check if(player). We could just remove it, and let the
-    // target player get assigned in the first update frame
-    this.targetId = Player.getRandomPlayer(this.gameId).id;
+    this.targetId = Player.getRandomLivingPlayerId(this.gameId);
     this.width = 32;
     this.height = 32;
 
@@ -51,10 +48,11 @@ class Enemy extends Entity {
     const game = GAMES[this.gameId];
     let targetPlayer = game.players[this.targetId];
     // if the target player died or left the game, get a new target
-    if (!targetPlayer) {
-      targetPlayer = Player.getRandomPlayer(this.gameId);
+    if (!targetPlayer || targetPlayer.dead) {
+      const newTargetId = Player.getRandomLivingPlayerId(this.gameId);
+      targetPlayer = game.players[newTargetId];
       if (targetPlayer) {
-        this.targetId = targetPlayer.id;
+        this.targetId = newTargetId;
       }
     }
     this.updateSpeed(targetPlayer);

--- a/dev/lib/game.js
+++ b/dev/lib/game.js
@@ -89,31 +89,31 @@ class Game {
       }
     }
     static findOrCreateGame() {
-        console.log('[findOrCreateGame] Current games:', numIds(GAMES));
-        console.log('[findOrCreateGame] Searching for available games...');
-        const maxPlayersPerGame = 4;
-        const gameIds = ids(GAMES);
-        for (let i = 0; i < gameIds.length; i++) {
-          const gameId = gameIds[i];
-          const existingGame = GAMES[gameId];
-          const numCurrentPlayers = numIds(existingGame.players);
-          console.log('[findOrCreateGame] Existing game', gameId, 'found with', numCurrentPlayers, 'players');
-          if (numCurrentPlayers < maxPlayersPerGame) {
-            console.log('[findOrCreateGame] Available game found:', existingGame.id);
-            return existingGame;
-          }
+      console.log('[findOrCreateGame] Current games:', numIds(GAMES));
+      console.log('[findOrCreateGame] Searching for available games...');
+      const maxPlayersPerGame = 4;
+      const gameIds = ids(GAMES);
+      for (let i = 0; i < gameIds.length; i++) {
+        const gameId = gameIds[i];
+        const existingGame = GAMES[gameId];
+        const numCurrentPlayers = numIds(existingGame.players);
+        console.log('[findOrCreateGame] Existing game', gameId, 'found with', numCurrentPlayers, 'players');
+        if (numCurrentPlayers < maxPlayersPerGame) {
+          console.log('[findOrCreateGame] Available game found:', existingGame.id);
+          return existingGame;
         }
-        console.log('[findOrCreateGame] No available game found, creating new game');
-        return new Game();
+      }
+      console.log('[findOrCreateGame] No available game found, creating new game');
+      return new Game();
     }
     static deleteIfEmpty(gameId) {
-        const game = GAMES[gameId];
-        if (game) {
-            const numCurrentPlayers = numIds(game.players);
-            if (numCurrentPlayers == 0) {
-                delete GAMES[gameId];
-            }
+      const game = GAMES[gameId];
+      if (game) {
+        const numCurrentPlayers = numIds(game.players);
+        if (numCurrentPlayers == 0) {
+          delete GAMES[gameId];
         }
+      }
     }
   }
   Game.entities = {

--- a/dev/static/style.css
+++ b/dev/static/style.css
@@ -134,7 +134,7 @@ a:hover, a:focus {
   flex-direction: column;
 }
 
-.startScreen {
+.screen {
   align-items: center;
   display: flex;
   height: 100%;
@@ -142,7 +142,7 @@ a:hover, a:focus {
   width: 100%;
 }
 
-.startScreenMenu {
+.menu {
   align-items: center;
   background-color: #000;
   border: 1px solid #4a4a4a;
@@ -154,6 +154,7 @@ a:hover, a:focus {
   width: 50%;
   padding: 0 0 20px 0;
   max-width: 600px;
+  min-height: 500px;
 }
 
 .btn {
@@ -173,4 +174,8 @@ a:hover, a:focus {
   /* Player one's color */
   color: #FF5733;
   border: 1px solid #FF5733;
+}
+
+.hidden {
+  display: none;
 }


### PR DESCRIPTION
- adds a game over screen that shows team score, player score, and wave reached
- sets this.dead = true in Player instead of removal when out of lives
- checks if all the players in a game are dead in setInterval and sends a gameOver socket event to the client
- gameOver socket listener on client gets the game stats, shows the game over screen, and removes all sprite objects
- render loop stops if the game is over
- renderLoop starts when start button is clicked so that the game starts again if players replay w/o refreshing
- adds !player.dead check to bullet collisions
- getRandomPlayer for enemy targeting changed to getRandomLivingPlayer so that they don't target a dead player
- wraps logic in player update() with a !this.dead check so that it only runs if the player is still alive